### PR TITLE
522-534-571: Criação das Classes AppDbContext e NewsConfiguration.

### DIFF
--- a/GwiNews/GwiNews.API/GwiNews.API.csproj
+++ b/GwiNews/GwiNews.API/GwiNews.API.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/GwiNews/GwiNews.API/Program.cs
+++ b/GwiNews/GwiNews.API/Program.cs
@@ -1,3 +1,6 @@
+using GwiNews.Infra.Data.Context;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -6,6 +9,9 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddDbContext<AppDbContext>(option =>
+    option.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 var app = builder.Build();
 

--- a/GwiNews/GwiNews.API/appsettings.json
+++ b/GwiNews/GwiNews.API/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=DESKTOP-G792N2O\\SQLEXPRESS;database=GwiNews;trusted_connection=true;trustservercertificate=true;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/GwiNews/GwiNews.Domain/Entities/News.cs
+++ b/GwiNews/GwiNews.Domain/Entities/News.cs
@@ -26,7 +26,11 @@ namespace GwiNews.Domain.Entities
         [Required]
         public DateTime? PublishDate { get; set; }
         [Required]
+        public Guid? AuthorId { get; set; }
+        [Required]
         public UserWithNews? Author { get; set; }
+        [Required]
+        public Guid? EditorId { get; set; }
         [Required]
         public UserWithNews? Editor { get; set; }
     }

--- a/GwiNews/GwiNews.Domain/Entities/UserWithNews.cs
+++ b/GwiNews/GwiNews.Domain/Entities/UserWithNews.cs
@@ -23,6 +23,7 @@ namespace GwiNews.Domain.Entities
         public string? Password { get; set; }
         [Required]
         public bool? Status { get; set; }
-        public ICollection<News>? UserNews { get; set; }
+        public ICollection<News>? AuthoredNews { get; set; }
+        public ICollection<News>? EditedNews { get; set; }
     }
 }

--- a/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
+++ b/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
@@ -1,0 +1,21 @@
+﻿using GwiNews.Domain.Entities;
+using GwiNews.Infra.Data.EntityConfiguration;
+using Microsoft.EntityFrameworkCore;
+
+namespace GwiNews.Infra.Data.Context
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        { }
+
+        
+        public DbSet<News> News { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            
+            modelBuilder.ApplyConfiguration(new NewsConfiguration());
+        }
+    }
+}

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using GwiNews.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GwiNews.Infra.Data.EntityConfiguration
+{
+    public class NewsConfiguration : IEntityTypeConfiguration<News>
+    {
+        public void Configure(EntityTypeBuilder<News> builder)
+        {
+            builder.HasKey(n => n.Id);
+            builder.Property(n => n.Status).IsRequired();
+            builder.Property(n => n.NewsUrl).IsRequired().HasMaxLength(510);
+            builder.Property(n => n.Title).IsRequired().HasMaxLength(75);
+            builder.Property(n => n.Subtitle).IsRequired().HasMaxLength(255);
+            builder.Property(n => n.NewsBody).IsRequired().HasMaxLength(65535);
+            builder.Property(n => n.ImageUrl).IsRequired().HasMaxLength(510);
+            builder.Property(n => n.PublishDate).IsRequired();
+        }
+    }
+}

--- a/GwiNews/GwiNews.Infra.Data/GwiNews.Infra.Data.csproj
+++ b/GwiNews/GwiNews.Infra.Data/GwiNews.Infra.Data.csproj
@@ -7,6 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\GwiNews.Domain\GwiNews.Domain.csproj" />
   </ItemGroup>
 

--- a/GwiNews/GwiNews.sln
+++ b/GwiNews/GwiNews.sln
@@ -3,17 +3,17 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.11.35222.181
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GwiNews.API", "GwiNews.API\GwiNews.API.csproj", "{8AB484B3-4F65-469F-94D8-4971E00BA7FE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GwiNews.API", "GwiNews.API\GwiNews.API.csproj", "{8AB484B3-4F65-469F-94D8-4971E00BA7FE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GwiNews.Application", "GwiNews.Application\GwiNews.Application.csproj", "{50F64999-A4B5-4BB6-8830-B09E37F3F87F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GwiNews.Application", "GwiNews.Application\GwiNews.Application.csproj", "{50F64999-A4B5-4BB6-8830-B09E37F3F87F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GwiNews.Domain", "GwiNews.Domain\GwiNews.Domain.csproj", "{28447194-82AA-4AD7-A95A-E5BB6193C0B3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GwiNews.Domain", "GwiNews.Domain\GwiNews.Domain.csproj", "{28447194-82AA-4AD7-A95A-E5BB6193C0B3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GwiNews.Infra.Data", "GwiNews.Infra.Data\GwiNews.Infra.Data.csproj", "{90A3D07A-925F-41C7-AE88-9137B5A499E8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GwiNews.Infra.Data", "GwiNews.Infra.Data\GwiNews.Infra.Data.csproj", "{90A3D07A-925F-41C7-AE88-9137B5A499E8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GwiNews.Domain.Test", "GwiNews.Domain.Test\GwiNews.Domain.Test.csproj", "{C3933C97-F4D3-4296-8066-9C46C27FE6C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GwiNews.Domain.Test", "GwiNews.Domain.Test\GwiNews.Domain.Test.csproj", "{C3933C97-F4D3-4296-8066-9C46C27FE6C2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GwiNews.Infra.IoC", "GwiNews.Infra.IoC\GwiNews.Infra.IoC.csproj", "{46B36E78-4366-44BF-A5C8-2F2EB232D871}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GwiNews.Infra.IoC", "GwiNews.Infra.IoC\GwiNews.Infra.IoC.csproj", "{6F526F60-54E9-42FD-BA03-B943427FC772}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,10 +41,10 @@ Global
 		{C3933C97-F4D3-4296-8066-9C46C27FE6C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3933C97-F4D3-4296-8066-9C46C27FE6C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3933C97-F4D3-4296-8066-9C46C27FE6C2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{46B36E78-4366-44BF-A5C8-2F2EB232D871}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{46B36E78-4366-44BF-A5C8-2F2EB232D871}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{46B36E78-4366-44BF-A5C8-2F2EB232D871}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{46B36E78-4366-44BF-A5C8-2F2EB232D871}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F526F60-54E9-42FD-BA03-B943427FC772}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F526F60-54E9-42FD-BA03-B943427FC772}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F526F60-54E9-42FD-BA03-B943427FC772}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F526F60-54E9-42FD-BA03-B943427FC772}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 534/Task 571.
Data: 11/01/2025.

Log de Alterações:

- Adição: Diretórios Context e EntityConfiguration em GwiNews.Infra.Data;
- Adição: Classe AppDbContext em Context;
- Adição: DbSet News e ApplyConfigurations NewsConfiguration em AppDbContext;
- Adição: Classe NewsConfiguration em EntityConfiguration;
- Adição: Definição de PK e regras de negócio da entidade News em NewsConfiguration;
- Alteração: Instalação dos Pacotes NuGet Microsoft.EntityFrameworkCore, Microsoft.EntityFrameworkCore.Design, Microsoft.EntityFrameworkCore.SqlServer e Microsoft.EntityFrameworkCore.Tools em GwiNews.API;
- Alteração: Instalação dos Pacotes NuGet Microsoft.EntityFrameworkCore, Microsoft.EntityFrameworkCore.Design, Microsoft.EntityFrameworkCore.SqlServer e Microsoft.EntityFrameworkCore.Tools em GwiNews.Infra.Data;
- Alteração: Injeção de Dependência de Contexto de Banco de Dados e Connection String em Program.cs;
- Alteração: Adição de Connection String DefaultConnection em appsettings.json;
- Alteração: Propriedades AuthorId e EditorId adicionadas à News em Entites;
- Alteração: Propriedade UserNews substituída por AuthorNews e EditorNews em UserWithNews;