### PR TITLE
522-534-572: Criação de UserWithNews EntityConfiguration e DbContext.

### DIFF
--- a/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
+++ b/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
@@ -9,12 +9,12 @@ namespace GwiNews.Infra.Data.Context
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
         { }
 
-        
+        public DbSet<UserWithNews> UsersWithNews { get; set; }
         public DbSet<News> News { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            
+            modelBuilder.ApplyConfiguration(new UserWithNewsConfiguration());
             modelBuilder.ApplyConfiguration(new NewsConfiguration());
         }
     }

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/UserWithNewsConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/UserWithNewsConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using GwiNews.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GwiNews.Infra.Data.EntityConfiguration
+{
+    public class UserWithNewsConfiguration : IEntityTypeConfiguration<UserWithNews>
+    {
+        public void Configure(EntityTypeBuilder<UserWithNews> builder)
+        {
+            builder.HasKey(u => u.Id);
+            builder.Property(u => u.Role).IsRequired();
+            builder.Property(u => u.CompleteName).IsRequired().HasMaxLength(255);
+            builder.Property(u => u.Email).IsRequired().HasMaxLength(510);
+            builder.Property(u => u.Password).IsRequired().HasMaxLength(1020);
+            builder.Property(u => u.Status).IsRequired();
+            builder.HasMany(u => u.AuthoredNews).WithOne(n => n.Author).HasForeignKey(n => n.AuthorId).OnDelete(DeleteBehavior.Restrict);
+            builder.HasMany(u => u.EditedNews).WithOne(n => n.Editor).HasForeignKey(n => n.EditorId).OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 534/Task 572.
Data: 11/01/2025.

Log de Alterações:

- Adição: Classe UserWithNewsConfiguration em EntityConfiguration;
- Adição: Definição de PK, regras de negócio e relacionamento com News em UserWithNewsConfiguration;
- Alteração: AppDbContext configurado para receber DbSet UserWithNews e UserWithNewsConfiguration;