### PR TITLE
522-534-575: NewsCategory DbSet e EntityConfiguration.

### DIFF
--- a/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
+++ b/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
@@ -11,11 +11,13 @@ namespace GwiNews.Infra.Data.Context
 
         public DbSet<UserWithNews> UsersWithNews { get; set; }
         public DbSet<News> News { get; set; }
+        public DbSet<NewsCategory> NewsCategories { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.ApplyConfiguration(new UserWithNewsConfiguration());
             modelBuilder.ApplyConfiguration(new NewsConfiguration());
+            modelBuilder.ApplyConfiguration(new NewsCategoryConfiguration());
         }
     }
 }

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsCategoryConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsCategoryConfiguration.cs
@@ -1,0 +1,17 @@
+﻿using GwiNews.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GwiNews.Infra.Data.EntityConfiguration
+{
+    public class NewsCategoryConfiguration : IEntityTypeConfiguration<NewsCategory>
+    {
+        public void Configure(EntityTypeBuilder<NewsCategory> builder)
+        {
+            builder.HasKey(nc => nc.Id);
+            builder.Property(nc => nc.Name).IsRequired().HasMaxLength(25);
+            builder.HasMany(nc => nc.News).WithOne(n => n.Category).HasForeignKey(n => n.CategoryId).OnDelete(DeleteBehavior.Restrict);
+            builder.HasMany(nc => nc.Subcategories).WithOne(ns => ns.Category).HasForeignKey(ns => ns.CategoryId).OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 534/Task 575.
Data: 11/01/2025.

Log de Alterações:

- Adição: Classe NewsCategoryConfiguration em EntityConfiguration;
- Adição: Definição de PK, regras de negócio e FK dos relacionamentos entre News e NewsSubacategory com NewsCategory;
- Alteração: AppDbSet configurado para receber NewsCategory DbSet e NewsCategoryConfiguration;