### PR TITLE
522-534-576: NewsSubcategory DbSet e EntityConfiguration.

### DIFF
--- a/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
+++ b/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
@@ -12,12 +12,14 @@ namespace GwiNews.Infra.Data.Context
         public DbSet<UserWithNews> UsersWithNews { get; set; }
         public DbSet<News> News { get; set; }
         public DbSet<NewsCategory> NewsCategories { get; set; }
+        public DbSet<NewsSubcategory> NewsSubcategories { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.ApplyConfiguration(new UserWithNewsConfiguration());
             modelBuilder.ApplyConfiguration(new NewsConfiguration());
             modelBuilder.ApplyConfiguration(new NewsCategoryConfiguration());
+            modelBuilder.ApplyConfiguration(new NewsSubcategoryConfiguration());
         }
     }
 }

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsSubcategoryConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsSubcategoryConfiguration.cs
@@ -1,0 +1,16 @@
+﻿using GwiNews.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GwiNews.Infra.Data.EntityConfiguration
+{
+    public class NewsSubcategoryConfiguration :IEntityTypeConfiguration<NewsSubcategory>
+    {
+        public void Configure(EntityTypeBuilder<NewsSubcategory> builder)
+        {
+            builder.HasKey(ns => ns.Id);
+            builder.Property(ns => ns.Name).IsRequired().HasMaxLength(55);
+            builder.HasMany(ns => ns.News).WithMany(n => n.Subcategories);
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 534/Task 576.
Data: 11/01/2025.

Log de Alterações:

- Adição: Classe NewsSubcategoryConfiguration em EntityConfiguration;
- Adição: Definição de Pk, regras de negócio e FK de relacionamento com News em NewsSubcategory;
- Alteração: AppDbContext configurado para receber DbSet de NewsSubcategory e NewsSubcategoryConfiguration;