### PR TITLE
522-530-578: Criação da Classe ProfessionalInformation.

### DIFF
--- a/GwiNews/GwiNews.Domain/Entities/ProfessionalInformation.cs
+++ b/GwiNews/GwiNews.Domain/Entities/ProfessionalInformation.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GwiNews.Domain.Entities
+{
+    public class ProfessionalInformation
+    {
+        [Key]
+        public Guid? Id { get; set; }
+        [Required]
+        [StringLength(255)]
+        public string? CompleteName { get; set; }
+        [Required]
+        [StringLength(255)]
+        [EmailAddress]
+        public string? Email { get; set; }
+        [Required]
+        [StringLength(510)]
+        public string? CompleteAddress { get; set; }
+        [Required]
+        [StringLength(255)]
+        public string? Objective { get; set; }
+        [Required]
+        [StringLength(510)]
+        public string? ImgUrl { get; set; }
+        [StringLength(255)]
+        public string? WorkPlatformUrl { get; set; }
+        [Required]
+        public Guid? UserId { get; set; }
+        [Required]
+        public ReaderUser? User { get; set; }
+    }
+}

--- a/GwiNews/GwiNews.Domain/Entities/ReaderUser.cs
+++ b/GwiNews/GwiNews.Domain/Entities/ReaderUser.cs
@@ -24,5 +24,6 @@ namespace GwiNews.Domain.Entities
         [Required]
         public bool? Status { get; set; }
         public ICollection<News>? FavoritedNews { get; set; }
+        public ICollection<ProfessionalInformation>? ProfessionalInformations { get; set; }
     }
 }


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 530/Task 578.
Data: 11/01/2025.

Log de Alterações:

- Adição: Classe ProfessionalInformation em Entities;
- Adição: Propriedades Guid Id, string CompleteName, string Email, string CompleteAddress, string Objective, string WorkPlatformUrl, Guid UserId e ReaderUser User;
- Alteração: Propriedade ICollection<ProfessionalInformation> ProfessionalInformations em ReaderUser;