### PR TITLE
522-534-581: DbSet e EntityConfiguration de ReaderUsers.

### DIFF
--- a/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
+++ b/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
@@ -13,6 +13,10 @@ namespace GwiNews.Infra.Data.Context
         public DbSet<News> News { get; set; }
         public DbSet<NewsCategory> NewsCategories { get; set; }
         public DbSet<NewsSubcategory> NewsSubcategories { get; set; }
+        public DbSet<ReaderUser> ReaderUsers { get; set; }
+        public DbSet<ProfessionalInformation> ProfessionalInformations { get; set; }
+        public DbSet<ProfessionalSkill> ProfessionalSkills { get; set; }
+        public DbSet<Formation> Formations { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -20,6 +24,7 @@ namespace GwiNews.Infra.Data.Context
             modelBuilder.ApplyConfiguration(new NewsConfiguration());
             modelBuilder.ApplyConfiguration(new NewsCategoryConfiguration());
             modelBuilder.ApplyConfiguration(new NewsSubcategoryConfiguration());
+            modelBuilder.ApplyConfiguration(new ReaderUserConfiguration());
         }
     }
 }

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/ReaderUserConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/ReaderUserConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using GwiNews.Domain.Entities;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore;
+
+namespace GwiNews.Infra.Data.EntityConfiguration
+{
+    public class ReaderUserConfiguration : IEntityTypeConfiguration<ReaderUser>
+    {
+        public void Configure(EntityTypeBuilder<ReaderUser> builder)
+        {
+            builder.HasKey(u => u.Id);
+            builder.Property(u => u.Role).IsRequired();
+            builder.Property(u => u.CompleteName).IsRequired().HasMaxLength(255);
+            builder.Property(u => u.Email).IsRequired().HasMaxLength(510);
+            builder.Property(u => u.Password).IsRequired().HasMaxLength(1020);
+            builder.Property(u => u.Status).IsRequired();
+            builder.HasMany(u => u.FavoritedNews).WithMany(n => n.FavoritedBy);
+            builder.HasMany(u => u.ProfessionalInformations).WithOne(pi => pi.User).HasForeignKey(pi => pi.UserId).OnDelete(DeleteBehavior.Restrict);
+            builder.HasMany(u => u.ProfessionalSkills).WithOne(ps => ps.User).HasForeignKey(ps => ps.UserId).OnDelete(DeleteBehavior.Restrict);
+            builder.HasMany(u => u.Formations).WithOne(f => f.User).HasForeignKey(f => f.UserId).OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 534/Task 581.
Data: 11/01/2025.

Log de Alterações:

- Adição: Classe ReaderUserConfiguration em EntityConfiguration;
- Adição: Definições de PK, regras de negócio e FK de relacionamentos com News, ProfessionalInformation, ProfessionalSkill e Formation em ReaderUserConfiguration;
- Alteração: Configuração de AppDbContext para receber DbSet ReaderUser e ReaderUserConfiguration;