### PR TITLE
522-534-582: Professional Information DbSet e Configuration.

### DIFF
--- a/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
+++ b/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
@@ -15,8 +15,6 @@ namespace GwiNews.Infra.Data.Context
         public DbSet<NewsSubcategory> NewsSubcategories { get; set; }
         public DbSet<ReaderUser> ReaderUsers { get; set; }
         public DbSet<ProfessionalInformation> ProfessionalInformations { get; set; }
-        public DbSet<ProfessionalSkill> ProfessionalSkills { get; set; }
-        public DbSet<Formation> Formations { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -25,6 +23,7 @@ namespace GwiNews.Infra.Data.Context
             modelBuilder.ApplyConfiguration(new NewsCategoryConfiguration());
             modelBuilder.ApplyConfiguration(new NewsSubcategoryConfiguration());
             modelBuilder.ApplyConfiguration(new ReaderUserConfiguration());
+            modelBuilder.ApplyConfiguration(new ProfessionalInformationConfiguration());
         }
     }
 }

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/ProfessionalInformationConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/ProfessionalInformationConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using GwiNews.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GwiNews.Infra.Data.EntityConfiguration
+{
+    public class ProfessionalInformationConfiguration : IEntityTypeConfiguration<ProfessionalInformation>
+    {
+        public void Configure(EntityTypeBuilder<ProfessionalInformation> builder)
+        {
+            builder.HasKey(pi => pi.Id);
+            builder.Property(pi => pi.CompleteName).IsRequired().HasMaxLength(255);
+            builder.Property(pi => pi.Email).IsRequired().HasMaxLength(255);
+            builder.Property(pi => pi.CompleteAddress).IsRequired().HasMaxLength(510);
+            builder.Property(pi => pi.Objective).IsRequired().HasMaxLength(255);
+            builder.Property(pi => pi.ImgUrl).IsRequired().HasMaxLength(510);
+            builder.Property(pi => pi.WorkPlatformUrl).HasMaxLength(255);
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 534/Task 582.
Data: 11/01/2025.

Log de Alterações:

- Adição: Classe ProfessionalInformationConfiguration em EntityConfiguration;
- Adição: Definição de PK e regras de negócio em ProfessionalInformationConfiguration;
- Alteração: Definição de DbSet<ProfessionalInformation> e ProfessionalInformationConfiguration em AppDbContext;