### PR TITLE
522-534-583: DbSet e EntityConfiguration para Professional Skill.

### DIFF
--- a/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
+++ b/GwiNews/GwiNews.Infra.Data/Context/AppDbContext.cs
@@ -15,6 +15,7 @@ namespace GwiNews.Infra.Data.Context
         public DbSet<NewsSubcategory> NewsSubcategories { get; set; }
         public DbSet<ReaderUser> ReaderUsers { get; set; }
         public DbSet<ProfessionalInformation> ProfessionalInformations { get; set; }
+        public DbSet<ProfessionalSkill> ProfessionalSkills { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -24,6 +25,7 @@ namespace GwiNews.Infra.Data.Context
             modelBuilder.ApplyConfiguration(new NewsSubcategoryConfiguration());
             modelBuilder.ApplyConfiguration(new ReaderUserConfiguration());
             modelBuilder.ApplyConfiguration(new ProfessionalInformationConfiguration());
+            modelBuilder.ApplyConfiguration(new ProfessionalSkillConfiguration());
         }
     }
 }

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/ProfessionalSkillConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/ProfessionalSkillConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using GwiNews.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GwiNews.Infra.Data.EntityConfiguration
+{
+    public class ProfessionalSkillConfiguration : IEntityTypeConfiguration<ProfessionalSkill>
+    {
+        public void Configure(EntityTypeBuilder<ProfessionalSkill> builder)
+        {
+            builder.HasKey(ps => ps.Id);
+            builder.Property(ps => ps.Skill1).IsRequired().HasMaxLength(55);
+            builder.Property(ps => ps.Skill2).IsRequired().HasMaxLength(55);
+            builder.Property(ps => ps.Skill3).IsRequired().HasMaxLength(55);
+            builder.Property(ps => ps.Skill4).IsRequired().HasMaxLength(55);
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 534/Task 583.
Data: 11/01/2025.

Log de Alterações:

Adição: Classe ProfessionalSkillConfiguration em EntityConfiguration;
Adição: Definição de PK e regras de negócio em ProfessionalSkillConfiguration;
Alteração: Definição de DbSet e ProfessionalSkillConfiguration em AppDbContext;