### PR TITLE
522-531-586: Interface e Classe NewsRepository.

### DIFF
--- a/GwiNews/GwiNews.Domain/Entities/News.cs
+++ b/GwiNews/GwiNews.Domain/Entities/News.cs
@@ -43,9 +43,9 @@ namespace GwiNews.Domain.Entities
 
     public enum NewsStatus
     {
-        Publicada = 0,
-        EmRevisao = 1,
-        Rascunho = 2,
-        Inativa = 3
+        Published = 0,
+        InRevision = 1,
+        Draft = 2,
+        Inactive = 3
     }
 }

--- a/GwiNews/GwiNews.Domain/Interfaces/INewsRepository.cs
+++ b/GwiNews/GwiNews.Domain/Interfaces/INewsRepository.cs
@@ -1,0 +1,16 @@
+﻿using GwiNews.Domain.Entities;
+
+namespace GwiNews.Domain.Interfaces
+{
+    public interface INewsRepository
+    {
+        public Task<IEnumerable<News>> GetNews();
+        public Task<News> GetNewsById(Guid id);
+        public Task<IEnumerable<News>> GetPublishedNews();
+        public Task<IEnumerable<News>> GetDraftNews();
+        public Task<IEnumerable<News>> GetInRevisionNews();
+        public Task<News> CreateNews(News news);
+        public Task<News> UpdateNews(News news);
+        public Task<IEnumerable<News>> DeleteNews(News news);
+    }
+}

--- a/GwiNews/GwiNews.Infra.Data/Repository/NewsRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/NewsRepository.cs
@@ -1,0 +1,124 @@
+﻿using GwiNews.Domain.Entities;
+using GwiNews.Domain.Interfaces;
+using GwiNews.Infra.Data.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace GwiNews.Infra.Data.Repository
+{
+    public class NewsRepository : INewsRepository
+    {
+        private readonly AppDbContext _context;
+        public NewsRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<News>> GetNews()
+        {
+            try
+            {
+                var news = await _context.News.ToListAsync();
+                return news;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<News> GetNewsById(Guid id)
+        {
+            try
+            {
+                var news = await _context.News.FindAsync(id);
+                return news;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<IEnumerable<News>> GetPublishedNews()
+        {
+            try
+            {
+                var news = await _context.News.Where(n => n.Status == NewsStatus.Published).ToListAsync();
+                return news;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<IEnumerable<News>> GetDraftNews()
+        {
+            try
+            {
+                var news = await _context.News.Where(n => n.Status == NewsStatus.Draft).ToListAsync();
+                return news;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<IEnumerable<News>> GetInRevisionNews()
+        {
+            try
+            {
+                var news = await _context.News.Where(n => n.Status == NewsStatus.InRevision).ToListAsync();
+                return news;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<News> CreateNews(News news)
+        {
+            try
+            {
+                _context.News.Add(news);
+                await _context.SaveChangesAsync();
+                return news;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<News> UpdateNews(News news)
+        {
+            try
+            {
+                _context.Update(news);
+                await _context.SaveChangesAsync();
+                return news;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<IEnumerable<News>> DeleteNews(News news)
+        {
+            try
+            {
+                news.Status = NewsStatus.Inactive;
+                _context.Update(news);
+                await _context.SaveChangesAsync();
+                return await _context.News.ToListAsync();
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 531/Task 587.
Data: 12/01/2025.

Log de Alterações:

- Adição: Classe INewsRepository em Interfaces;
- Adição: Métodos Get, GetById, GetPublished, GetDraft, GetInRevision, Create, Update e Delete em INewsRepository;
- Adição: Classe NewsRepository que implementa a Interface INewsRepository;
- Alteração: Opções de Enum NewsStatus atualizadas para Published, Draft, InRevision e Inactive em News;