### PR TITLE
522-531-588: Interface e Classe NewsCategoryRepository.

### DIFF
--- a/GwiNews/GwiNews.Domain/Entities/NewsCategory.cs
+++ b/GwiNews/GwiNews.Domain/Entities/NewsCategory.cs
@@ -9,6 +9,8 @@ namespace GwiNews.Domain.Entities
         [Required]
         [StringLength(25)]
         public string? Name { get; set; }
+        [Required]
+        public bool? Status { get; set; }
         public ICollection<News>? News { get; set; }
         public ICollection<NewsSubcategory>? Subcategories { get; set; }
     }

--- a/GwiNews/GwiNews.Domain/Interfaces/INewsCategoryRepository.cs
+++ b/GwiNews/GwiNews.Domain/Interfaces/INewsCategoryRepository.cs
@@ -1,0 +1,14 @@
+﻿using GwiNews.Domain.Entities;
+
+namespace GwiNews.Domain.Interfaces
+{
+    public interface INewsCategoryRepository
+    {
+        public Task<IEnumerable<NewsCategory>> GetNewsCategories();
+        public Task<NewsCategory> GetNewsCategory(Guid id);
+        public Task<IEnumerable<NewsCategory>> GetActiveNewsCategories();
+        public Task<NewsCategory> CreateNewsCategory(NewsCategory newsCategory);
+        public Task<NewsCategory> UpdateNewsCategory(NewsCategory newsCategory);
+        public Task<IEnumerable<NewsCategory>> DeleteNewsCategory(NewsCategory newsCategory);
+    }
+}

--- a/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsCategoryConfiguration.cs
+++ b/GwiNews/GwiNews.Infra.Data/EntityConfiguration/NewsCategoryConfiguration.cs
@@ -10,6 +10,7 @@ namespace GwiNews.Infra.Data.EntityConfiguration
         {
             builder.HasKey(nc => nc.Id);
             builder.Property(nc => nc.Name).IsRequired().HasMaxLength(25);
+            builder.Property(nc => nc.Status).IsRequired();
             builder.HasMany(nc => nc.News).WithOne(n => n.Category).HasForeignKey(n => n.CategoryId).OnDelete(DeleteBehavior.Restrict);
             builder.HasMany(nc => nc.Subcategories).WithOne(ns => ns.Category).HasForeignKey(ns => ns.CategoryId).OnDelete(DeleteBehavior.Restrict);
         }

--- a/GwiNews/GwiNews.Infra.Data/Repository/NewsCategoryRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/NewsCategoryRepository.cs
@@ -1,0 +1,98 @@
+﻿using GwiNews.Domain.Entities;
+using GwiNews.Domain.Interfaces;
+using GwiNews.Infra.Data.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace GwiNews.Infra.Data.Repository
+{
+    public class NewsCategoryRepository : INewsCategoryRepository
+    {
+        private readonly AppDbContext _context;
+        public NewsCategoryRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<NewsCategory>> GetNewsCategories()
+        {
+            try
+            {
+                var newsCategory = await _context.NewsCategories.ToListAsync();
+                return newsCategory;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<NewsCategory> GetNewsCategory(Guid id)
+        {
+            try
+            {
+                var newsCategory = await _context.NewsCategories.FindAsync(id);
+                return newsCategory;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<IEnumerable<NewsCategory>> GetActiveNewsCategories()
+        {
+            try
+            {
+                var newsCategory = await _context.NewsCategories.Where(nc => nc.Status == true).ToListAsync();
+                return newsCategory;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<NewsCategory> CreateNewsCategory(NewsCategory newsCategory)
+        {
+            try
+            {
+                _context.NewsCategories.Add(newsCategory);
+                await _context.SaveChangesAsync();
+                return newsCategory;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<NewsCategory> UpdateNewsCategory(NewsCategory newsCategory)
+        {
+            try
+            {
+                _context.Update(newsCategory);
+                await _context.SaveChangesAsync();
+                return newsCategory;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
+        public async Task<IEnumerable<NewsCategory>> DeleteNewsCategory(NewsCategory newsCategory)
+        {
+            try
+            {
+                newsCategory.Status = false;
+                _context.Update(newsCategory);
+                await _context.SaveChangesAsync();
+                return await _context.NewsCategories.ToListAsync();
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 522/Feature 531/Task 588.
Data: 12/01/2025.

Log de Alterações:

- Adição: Classe INewsCategoryRepository em Interfaces;
- Adição: Métodos Get, GetById, GetActive,  Create, Update e Delete em INewsCategoryRepository;
- Adição: Classe NewsCategoryRepository que implementa a Interface INewsCategoryRepository;
- Alteração: Propriedade bool Status adicionada à NewsCategory em Entities;
- Alteração: Redefinição de regra de negócio de NewsCategory em NewsCategoryConfiguration;