### PR TITLE
523-537-596: DTOs Create e Update de News.

### DIFF
--- a/GwiNews/GwiNews.Application/DTOs/News/CreateNewsDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/News/CreateNewsDTO.cs
@@ -1,0 +1,25 @@
+﻿namespace GwiNews.Application.DTOs.News
+{
+    public class CreateNewsDTO
+    {
+        public NewsStatus? Status { get; set; }
+        public string? NewsUrl { get; set; }
+        public string? Title { get; set; }
+        public string? Subtitle { get; set; }
+        public string? NewsBody { get; set; }
+        public string? ImageUrl { get; set; }
+        public DateTime? PublishDate { get; set; }
+        public Guid? AuthorId { get; set; }
+        public Guid? EditorId { get; set; }
+        public Guid? CategoryId { get; set; }
+        public ICollection<Guid>? Subcategories { get; set; }
+    }
+
+    public enum NewsStatus
+    {
+        Published = 0,
+        InRevision = 1,
+        Draft = 2,
+        Inactive = 3
+    }
+}

--- a/GwiNews/GwiNews.Application/DTOs/News/UpdateNewsDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/News/UpdateNewsDTO.cs
@@ -1,0 +1,18 @@
+﻿namespace GwiNews.Application.DTOs.News
+{
+    public class UpdateNewsDTO
+    {
+        public Guid? Id { get; set; }
+        public NewsStatus? Status { get; set; }
+        public string? NewsUrl { get; set; }
+        public string? Title { get; set; }
+        public string? Subtitle { get; set; }
+        public string? NewsBody { get; set; }
+        public string? ImageUrl { get; set; }
+        public DateTime? PublishDate { get; set; }
+        public Guid? AuthorId { get; set; }
+        public Guid? EditorId { get; set; }
+        public Guid? CategoryId { get; set; }
+        public ICollection<Guid>? Subcategories { get; set; }
+    }
+}


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 523/Feature 537/Task 596.
Data: 14/01/2025.

Log de Alterações:

- Adição: Diretório News em DTOs;
- Adição: Classes CreateNewsDTO e UpdateNewsDTO em News;
- Adição: Propriedades NewsStatus Status, string NewsUrl, string Title, string Subtitle, string NewsBody, string ImageUrl, DateTime PublishDate, Guid AuthorId, Guid EditorId, Guid CategoryId e ICollection<Guid> Subcategories em CreateNewsDTO;
- Adição: Enum NewsStatus em CreateNewsDTO;
- Adição: Enum Options Published, InRevision, Draft e Inactive em NewsStatus;
- Adição: Propriedades Guid Id, NewsStatus Status, string NewsUrl, string Title, string Subtitle, string NewsBody, string ImageUrl, DateTime PublishDate, Guid AuthorId, Guid EditorId, Guid CategoryId e ICollection<Guid> Subcategories em CreateNewsDTO;