### PR TITLE
523-542-606: Renomeação da Rota de User WIth News Controller.

### DIFF
--- a/GwiNews/GwiNews.API/Controllers/UserWithNewsController.cs
+++ b/GwiNews/GwiNews.API/Controllers/UserWithNewsController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GwiNews.API.Controllers
 {
-    [Route("api/[controller]")]
+    [Route("GwiNewsAPI/Usuários-com-Notícias")]
     [ApiController]
     public class UserWithNewsController : ControllerBase
     {


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 523/Feature 542/Task 606.
Data: 16/01/2025.

Log de Alterações:

- Alteração: Renomeação da Rota do Controlador UserWithNewsController para "GwiNewsAPI/Usuários-com-Notícias";