### PR TITLE
523-539-611: Interface e Classe News Category Service.

### DIFF
--- a/GwiNews/GwiNews.Application/Interfaces/INewsCategoryService.cs
+++ b/GwiNews/GwiNews.Application/Interfaces/INewsCategoryService.cs
@@ -1,0 +1,16 @@
+﻿using GwiNews.Application.DTOs;
+using GwiNews.Application.DTOs.NewsCategory;
+using GwiNews.Domain.Entities;
+
+namespace GwiNews.Application.Interfaces
+{
+    public interface INewsCategoryService
+    {
+        Task<ResponseModelDTO<IEnumerable<NewsCategory>>> GetNewsCategories();
+        Task<ResponseModelDTO<NewsCategory>> GetNewsCategory(Guid id);
+        Task<ResponseModelDTO<IEnumerable<NewsCategory>>> GetActiveNewsCategories();
+        Task<ResponseModelDTO<NewsCategory>> CreateNewsCategory(CreateNewsCategoryDTO createNewsCategoryDTO);
+        Task<ResponseModelDTO<NewsCategory>> UpdateNewsCategory(UpdateNewsCategoryDTO updateNewsCategoryDTO);
+        Task<ResponseModelDTO<IEnumerable<NewsCategory>>> DeleteNewsCategory(UpdateNewsCategoryDTO updateNewsCategoryDTO);
+    }
+}

--- a/GwiNews/GwiNews.Application/Services/NewsCategoryService.cs
+++ b/GwiNews/GwiNews.Application/Services/NewsCategoryService.cs
@@ -1,0 +1,132 @@
+﻿using AutoMapper;
+using GwiNews.Application.DTOs;
+using GwiNews.Application.DTOs.NewsCategory;
+using GwiNews.Application.Interfaces;
+using GwiNews.Domain.Entities;
+using GwiNews.Domain.Interfaces;
+
+namespace GwiNews.Application.Services
+{
+    public class NewsCategoryService : INewsCategoryService
+    {
+        private readonly INewsCategoryRepository _newsCategoryRepository;
+        private readonly IMapper _mapper;
+
+        public NewsCategoryService(INewsCategoryRepository newsCategoryRepository, IMapper mapper)
+        {
+            _newsCategoryRepository = newsCategoryRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<ResponseModelDTO<IEnumerable<NewsCategory>>> GetNewsCategories()
+        {
+            ResponseModelDTO<IEnumerable<NewsCategory>> response = new ResponseModelDTO<IEnumerable<NewsCategory>>();
+            try
+            {
+                var newsCategories = await _newsCategoryRepository.GetNewsCategories();
+                response.Data = newsCategories;
+                response.Message = "Categorias de Notícias Listadas com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<NewsCategory>> GetNewsCategory(Guid id)
+        {
+            ResponseModelDTO<NewsCategory> response = new ResponseModelDTO<NewsCategory>();
+            try
+            {
+                var newsCategory = await _newsCategoryRepository.GetNewsCategory(id);
+                response.Data = newsCategory;
+                response.Message = "Categoria de Notícia Listada com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<IEnumerable<NewsCategory>>> GetActiveNewsCategories()
+        {
+            ResponseModelDTO<IEnumerable<NewsCategory>> response = new ResponseModelDTO<IEnumerable<NewsCategory>>();
+            try
+            {
+                var newsCategories = await _newsCategoryRepository.GetActiveNewsCategories();
+                response.Data = newsCategories;
+                response.Message = "Categorias de Notícias Ativas Listadas com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<NewsCategory>> CreateNewsCategory(CreateNewsCategoryDTO createNewsCategoryDTO)
+        {
+            ResponseModelDTO<NewsCategory> response = new ResponseModelDTO<NewsCategory>();
+            try
+            {
+                var newsCategory = _mapper.Map<NewsCategory>(createNewsCategoryDTO);
+                newsCategory = await _newsCategoryRepository.CreateNewsCategory(newsCategory);
+                response.Data = newsCategory;
+                response.Message = "Categoria de Notícia Criada com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<NewsCategory>> UpdateNewsCategory(UpdateNewsCategoryDTO updateNewsCategoryDTO)
+        {
+            ResponseModelDTO<NewsCategory> response = new ResponseModelDTO<NewsCategory>();
+            try
+            {
+                var newsCategory = _mapper.Map<NewsCategory>(updateNewsCategoryDTO);
+                newsCategory = await _newsCategoryRepository.UpdateNewsCategory(newsCategory);
+                response.Data = newsCategory;
+                response.Message = "Categoria de Notícia Atualizada com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<IEnumerable<NewsCategory>>> DeleteNewsCategory(UpdateNewsCategoryDTO updateNewsCategoryDTO)
+        {
+            ResponseModelDTO<IEnumerable<NewsCategory>> response = new ResponseModelDTO<IEnumerable<NewsCategory>>();
+            try
+            {
+                var newsCategory = _mapper.Map<NewsCategory>(updateNewsCategoryDTO);
+                var newsCategories = await _newsCategoryRepository.DeleteNewsCategory(newsCategory);
+                response.Data = newsCategories;
+                response.Message = "Categoria de Notícia Excluída com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+    }
+}

--- a/GwiNews/GwiNews.Infra.Data/Repository/NewsCategoryRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/NewsCategoryRepository.cs
@@ -30,7 +30,10 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
-                var newsCategory = await _context.NewsCategories.FindAsync(id);
+                var newsCategory = await _context.NewsCategories
+                    .Include(nc => nc.News)
+                    .Include(nc => nc.Subcategories)
+                    .FirstOrDefaultAsync(nc => nc.Id == id);
                 return newsCategory;
             }
             catch (Exception ex)
@@ -87,7 +90,7 @@ namespace GwiNews.Infra.Data.Repository
                 newsCategory.Status = false;
                 _context.Update(newsCategory);
                 await _context.SaveChangesAsync();
-                return await _context.NewsCategories.ToListAsync();
+                return await _context.NewsCategories.Where(nc => nc.Status == true).ToListAsync();
             }
             catch (Exception ex)
             {

--- a/GwiNews/GwiNews.Infra.IoC/DependencyInjectionAPI.cs
+++ b/GwiNews/GwiNews.Infra.IoC/DependencyInjectionAPI.cs
@@ -28,6 +28,7 @@ namespace GwiNews.Infra.IoC
 
             services.AddScoped<IUserWithNewsService, UserWithNewsService>();
             services.AddScoped<INewsService, NewsService>();
+            services.AddScoped<INewsCategoryService, NewsCategoryService>();
 
             services.AddAutoMapper(typeof(DomainToDtoMappingProfile));
 


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 523/Feature 539/Task 611.
Data: 16/01/2025.

Log de Alterações:

- Adição: Interface INewsCategoryService em Interfaces;
- Adição: Métodos Get, GetById, GetActive, Create, Update e Delete em INewsCategoryService;
- Adição: Classe NewsCategoryService em Services;
- Adição: Implementação da Interface e Métodos de INewsCategoryService em NewsCategoryService;
- Alteração: Método GetById configurado para incluir listas de relacionamentos News e NewsSubcategories em NewsCategoryRepository;
- Alteração: Método Delete configurado para retornar NewsCategory com Status true em NewsCategoryRepository;
- Alteração: DependencyInjectionAPI configurado para receber associação de Interface e Classe de NewsCategoryService;