### PR TITLE
523-539-614: Interface e Classe News Subcategory Service.

### DIFF
--- a/GwiNews/GwiNews.Application/Interfaces/INewsSubcategoryService.cs
+++ b/GwiNews/GwiNews.Application/Interfaces/INewsSubcategoryService.cs
@@ -1,0 +1,17 @@
+﻿using GwiNews.Application.DTOs;
+using GwiNews.Application.DTOs.NewsSubcategory;
+using GwiNews.Domain.Entities;
+
+namespace GwiNews.Application.Interfaces
+{
+    public interface INewsSubcategoryService
+    {
+        Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> GetNewsSubcategories();
+        Task<ResponseModelDTO<NewsSubcategory>> GetNewsSubcategory(Guid id);
+        Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> GetNewsSubcategoriesByCategoryId(Guid id);
+        Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> GetActiveNewsSubcategories();
+        Task<ResponseModelDTO<NewsSubcategory>> CreateNewsSubcategory(CreateNewsSubcategoryDTO createNewsSubcategoryDTO);
+        Task<ResponseModelDTO<NewsSubcategory>> UpdateNewsSubcategory(UpdateNewsSubcategoryDTO updateNewsSubcategoryDTO);
+        Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> DeleteNewsSubcategory(UpdateNewsSubcategoryDTO updateNewsSubcategoryDTO);
+    }
+}

--- a/GwiNews/GwiNews.Application/Services/NewsSubcategoryService.cs
+++ b/GwiNews/GwiNews.Application/Services/NewsSubcategoryService.cs
@@ -1,0 +1,149 @@
+﻿using AutoMapper;
+using GwiNews.Application.DTOs;
+using GwiNews.Application.DTOs.NewsSubcategory;
+using GwiNews.Application.Interfaces;
+using GwiNews.Domain.Entities;
+using GwiNews.Domain.Interfaces;
+
+namespace GwiNews.Application.Services
+{
+    public class NewsSubcategoryService : INewsSubcategoryService
+    {
+        private readonly INewsSubcategoryRepository _newsSubcategoryRepository;
+        private readonly IMapper _mapper;
+        public NewsSubcategoryService(INewsSubcategoryRepository newsSubcategoryRepository, IMapper mapper)
+        {
+            _newsSubcategoryRepository = newsSubcategoryRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> GetNewsSubcategories()
+        {
+            ResponseModelDTO<IEnumerable<NewsSubcategory>> response = new ResponseModelDTO<IEnumerable<NewsSubcategory>>();
+            try
+            {
+                var newsSubcategories = await _newsSubcategoryRepository.GetNewsSubcategories();
+                response.Data = newsSubcategories;
+                response.Message = "Subcategorias de Notícias Listadas com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<NewsSubcategory>> GetNewsSubcategory(Guid id)
+        {
+            ResponseModelDTO<NewsSubcategory> response = new ResponseModelDTO<NewsSubcategory>();
+            try
+            {
+                var newsSubcategory = await _newsSubcategoryRepository.GetNewsSubcategory(id);
+                response.Data = newsSubcategory;
+                response.Message = "Subcategoria de Notícia Listada com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> GetNewsSubcategoriesByCategoryId(Guid id)
+        {
+            ResponseModelDTO<IEnumerable<NewsSubcategory>> response = new ResponseModelDTO<IEnumerable<NewsSubcategory>>();
+            try
+            {
+                var newsSubcategories = await _newsSubcategoryRepository.GetNewsSubcategoriesByCategoryId(id);
+                response.Data = newsSubcategories;
+                response.Message = "Subcategorias de Notícias por Categoria Listadas com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> GetActiveNewsSubcategories()
+        {
+            ResponseModelDTO<IEnumerable<NewsSubcategory>> response = new ResponseModelDTO<IEnumerable<NewsSubcategory>>();
+            try
+            {
+                var newsSubcategories = await _newsSubcategoryRepository.GetActiveNewsSubcategories();
+                response.Data = newsSubcategories;
+                response.Message = "Subcategorias de Notícias Ativas Listadas com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<NewsSubcategory>> CreateNewsSubcategory(CreateNewsSubcategoryDTO createNewsSubcategoryDTO)
+        {
+            ResponseModelDTO<NewsSubcategory> response = new ResponseModelDTO<NewsSubcategory>();
+            try
+            {
+                var newsSubcategory = _mapper.Map<NewsSubcategory>(createNewsSubcategoryDTO);
+                var newsSubcategoryCreated = await _newsSubcategoryRepository.CreateNewsSubcategory(newsSubcategory);
+                response.Data = newsSubcategoryCreated;
+                response.Message = "Subcategoria de Notícia Criada com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<NewsSubcategory>> UpdateNewsSubcategory(UpdateNewsSubcategoryDTO updateNewsSubcategoryDTO)
+        {
+            ResponseModelDTO<NewsSubcategory> response = new ResponseModelDTO<NewsSubcategory>();
+            try
+            {
+                var newsSubcategory = _mapper.Map<NewsSubcategory>(updateNewsSubcategoryDTO);
+                var newsSubcategoryUpdated = await _newsSubcategoryRepository.UpdateNewsSubcategory(newsSubcategory);
+                response.Data = newsSubcategoryUpdated;
+                response.Message = "Subcategoria de Notícia Atualizada com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<IEnumerable<NewsSubcategory>>> DeleteNewsSubcategory(UpdateNewsSubcategoryDTO updateNewsSubcategoryDTO)
+        {
+            ResponseModelDTO<IEnumerable<NewsSubcategory>> response = new ResponseModelDTO<IEnumerable<NewsSubcategory>>();
+            try
+            {
+                var newsSubcategory = _mapper.Map<NewsSubcategory>(updateNewsSubcategoryDTO);
+                var newsSubcategories = await _newsSubcategoryRepository.DeleteNewsSubcategory(newsSubcategory);
+                response.Data = newsSubcategories;
+                response.Message = "Subcategoria de Notícia Excluída com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+    }
+}

--- a/GwiNews/GwiNews.Domain/Interfaces/INewsSubcategoryRepository.cs
+++ b/GwiNews/GwiNews.Domain/Interfaces/INewsSubcategoryRepository.cs
@@ -6,6 +6,7 @@ namespace GwiNews.Domain.Interfaces
     {
         public Task<IEnumerable<NewsSubcategory>> GetNewsSubcategories();
         public Task<NewsSubcategory> GetNewsSubcategory(Guid id);
+        public Task<IEnumerable<NewsSubcategory>> GetNewsSubcategoriesByCategoryId(Guid id);
         public Task<IEnumerable<NewsSubcategory>> GetActiveNewsSubcategories();
         public Task<NewsSubcategory> CreateNewsSubcategory(NewsSubcategory newsSubcategory);
         public Task<NewsSubcategory> UpdateNewsSubcategory(NewsSubcategory newsSubcategory);

--- a/GwiNews/GwiNews.Infra.Data/Repository/NewsSubcategoryRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/NewsSubcategoryRepository.cs
@@ -39,6 +39,21 @@ namespace GwiNews.Infra.Data.Repository
             }
         }
 
+        public async Task<IEnumerable<NewsSubcategory>> GetNewsSubcategoriesByCategoryId(Guid id)
+        {
+            try
+            {
+                var newsSubcategory = await _context.NewsSubcategories
+                    .Where(ns => ns.CategoryId == id)
+                    .ToListAsync();
+                return newsSubcategory;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
         public async Task<IEnumerable<NewsSubcategory>> GetActiveNewsSubcategories()
         {
             try
@@ -87,7 +102,7 @@ namespace GwiNews.Infra.Data.Repository
                 newsSubcategory.Status = false;
                 _context.Update(newsSubcategory);
                 await _context.SaveChangesAsync();
-                return await _context.NewsSubcategories.ToListAsync();
+                return await _context.NewsSubcategories.Where(ns => ns.Status == true).ToListAsync();
             }
             catch (Exception ex)
             {

--- a/GwiNews/GwiNews.Infra.IoC/DependencyInjectionAPI.cs
+++ b/GwiNews/GwiNews.Infra.IoC/DependencyInjectionAPI.cs
@@ -29,6 +29,7 @@ namespace GwiNews.Infra.IoC
             services.AddScoped<IUserWithNewsService, UserWithNewsService>();
             services.AddScoped<INewsService, NewsService>();
             services.AddScoped<INewsCategoryService, NewsCategoryService>();
+            services.AddScoped<INewsSubcategoryService, NewsSubcategoryService>();
 
             services.AddAutoMapper(typeof(DomainToDtoMappingProfile));
 


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 523/Feature 539/Task 614.
Data: 16/01/2025.

Log de Alterações:

- Adição: Interface INewsSubcategoryService em Interfaces;
- Adição: Métodos Get, GetById, GetByCategoryId, GetActive, Create, Update e Delete em INewsSubcategoryService;
- Adição: Classe NewsSubcategoryService em Services;
- Adição: Implementação da Interface e Métodos de INewsSubcategoryService em NewsSubcategoryService;
- Alteração: Adição do Método GetSubcategoriesByCategoryId em INewsSubcategoryRepository;
- Alteração: Implementação do Método GetSubcategoriesByCategoryId em NewsSubcategoryRepository;
- Alteração: Método Delete configurado para retornar NewsSubcategory com Status true em NewsSubcategoryRepository;
- Alteração: DependencyInjectionAPI configurado para receber associação de Interface e Classe de NewsSubcategoryService;