### PR TITLE
524-544-629: Streaming de Dados Firestore para SQL Server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Environment Variables
+gwinews-firestore-api-key.json

--- a/GwiNews/GwiNews.API/Controllers/FirestoreToSqlServerDataStreamingController.cs
+++ b/GwiNews/GwiNews.API/Controllers/FirestoreToSqlServerDataStreamingController.cs
@@ -1,0 +1,28 @@
+﻿using GwiNews.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GwiNews.API.Controllers
+{
+    [Route("GwiNewsAPI/Streaming-de-Dados-Firestore-para-SQL-Server")]
+    [ApiController]
+    public class FirestoreToSqlServerDataStreamingController : ControllerBase
+    {
+        private readonly IFirestoreToSqlServerDataStreamingService _firestoreToSqlServerDataStreamingService;
+        public FirestoreToSqlServerDataStreamingController(IFirestoreToSqlServerDataStreamingService firestoreToSqlServerDataStreamingService)
+        {
+            _firestoreToSqlServerDataStreamingService = firestoreToSqlServerDataStreamingService;
+        }
+
+        [HttpGet("Iniciar-Streaming-de-Dados")]
+        public async Task<IActionResult> DataStreamingCaller()
+        {
+            var response = await _firestoreToSqlServerDataStreamingService.DataStreamingCaller();
+            if (response.Status)
+            {
+                return Ok(response);
+            }
+            return BadRequest(response);
+        }
+    }
+}

--- a/GwiNews/GwiNews.Application/DTOs/EnumDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/EnumDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace GwiNews.Application.DTOs
 {
-    public enum UserRole
+    public enum UserRoleDTO
     {
         Administrator = 0,
         Editor = 1,
@@ -10,7 +10,7 @@
         Financial = 5
     }
 
-    public enum NewsStatus
+    public enum NewsStatusDTO
     {
         Published = 0,
         InRevision = 1,

--- a/GwiNews/GwiNews.Application/DTOs/News/CreateNewsDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/News/CreateNewsDTO.cs
@@ -2,7 +2,7 @@
 {
     public class CreateNewsDTO
     {
-        public NewsStatus? Status { get; set; }
+        public NewsStatusDTO? Status { get; set; }
         public string? NewsUrl { get; set; }
         public string? Title { get; set; }
         public string? Subtitle { get; set; }

--- a/GwiNews/GwiNews.Application/DTOs/News/UpdateNewsDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/News/UpdateNewsDTO.cs
@@ -3,7 +3,7 @@
     public class UpdateNewsDTO
     {
         public Guid? Id { get; set; }
-        public NewsStatus? Status { get; set; }
+        public NewsStatusDTO? Status { get; set; }
         public string? NewsUrl { get; set; }
         public string? Title { get; set; }
         public string? Subtitle { get; set; }
@@ -13,6 +13,6 @@
         public Guid? AuthorId { get; set; }
         public Guid? EditorId { get; set; }
         public Guid? CategoryId { get; set; }
-        public ICollection<Guid>? Subcategories { get; set; }
+        public ICollection<Domain.Entities.NewsSubcategory>? Subcategories { get; set; }
     }
 }

--- a/GwiNews/GwiNews.Application/DTOs/ReaderUser/CreateReaderUserDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/ReaderUser/CreateReaderUserDTO.cs
@@ -2,7 +2,7 @@
 {
     public class CreateReaderUserDTO
     {
-        public UserRole? Role { get; set; }
+        public UserRoleDTO? Role { get; set; }
         public string? CompleteName { get; set; }
         public string? Email { get; set; }
         public string? Password { get; set; }

--- a/GwiNews/GwiNews.Application/DTOs/ReaderUser/UpdateReaderUserDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/ReaderUser/UpdateReaderUserDTO.cs
@@ -3,7 +3,7 @@
     public class UpdateReaderUserDTO
     {
         public Guid? Id { get; set; }
-        public UserRole? Role { get; set; }
+        public UserRoleDTO? Role { get; set; }
         public string? CompleteName { get; set; }
         public string? Email { get; set; }
         public string? Password { get; set; }

--- a/GwiNews/GwiNews.Application/DTOs/UserWithNews/CreateUserWithNewsDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/UserWithNews/CreateUserWithNewsDTO.cs
@@ -2,7 +2,7 @@
 {
     public class CreateUserWithNewsDTO
     {
-        public UserRole? Role { get; set; }
+        public UserRoleDTO? Role { get; set; }
         public string? CompleteName { get; set; }
         public string? Email { get; set; }
         public string? Password { get; set; }

--- a/GwiNews/GwiNews.Application/DTOs/UserWithNews/UpdateUserWithNewsDTO.cs
+++ b/GwiNews/GwiNews.Application/DTOs/UserWithNews/UpdateUserWithNewsDTO.cs
@@ -3,7 +3,7 @@
     public class UpdateUserWithNewsDTO
     {
         public Guid? Id { get; set; }
-        public UserRole? Role { get; set; }
+        public UserRoleDTO? Role { get; set; }
         public string? CompleteName { get; set; }
         public string? Email { get; set; }
         public string? Password { get; set; }

--- a/GwiNews/GwiNews.Application/GwiNews.Application.csproj
+++ b/GwiNews/GwiNews.Application/GwiNews.Application.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
+    <PackageReference Include="Google.Cloud.Firestore" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GwiNews/GwiNews.Application/Interfaces/IFirestoreToSqlServerDataStreamingService.cs
+++ b/GwiNews/GwiNews.Application/Interfaces/IFirestoreToSqlServerDataStreamingService.cs
@@ -1,0 +1,18 @@
+﻿using GwiNews.Application.DTOs;
+using GwiNews.Domain.Entities;
+
+namespace GwiNews.Application.Interfaces
+{
+    public interface IFirestoreToSqlServerDataStreamingService
+    {
+        public Task<ResponseModelDTO<bool>> DataStreamingCaller();
+        public Task<ResponseModelDTO<bool>> UserWithNewsDataStreaming();
+        public Task<ResponseModelDTO<bool>> NewsCategoryDataStreaming();
+        public Task<ResponseModelDTO<bool>> NewsSubcategoryDataStreaming();
+        public Task<ResponseModelDTO<bool>> NewsDataStreaming();
+        public Task<ResponseModelDTO<bool>> ReaderUserDataStreaming();
+        public Task<ResponseModelDTO<bool>> ProfessionalInformationDataStreaming();
+        public Task<ResponseModelDTO<bool>> ProfessionalSkillNewsDataStreaming();
+        public Task<ResponseModelDTO<bool>> FormationNewsDataStreaming();
+    }
+}

--- a/GwiNews/GwiNews.Application/Services/FirestoreToSqlServerDataStreamingService.cs
+++ b/GwiNews/GwiNews.Application/Services/FirestoreToSqlServerDataStreamingService.cs
@@ -1,0 +1,486 @@
+﻿using AutoMapper;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Firestore;
+using Google.Cloud.Firestore.V1;
+using GwiNews.Application.DTOs;
+using GwiNews.Application.DTOs.News;
+using GwiNews.Application.Interfaces;
+using GwiNews.Domain.Entities;
+using GwiNews.Domain.Interfaces;
+
+namespace GwiNews.Application.Services
+{
+    public class FirestoreToSqlServerDataStreamingService : IFirestoreToSqlServerDataStreamingService
+    {
+        private readonly IUserWithNewsRepository _userWithNewsRepository;
+        private readonly INewsRepository _newsRepository;
+        private readonly INewsCategoryRepository _newsCategoryRepository;
+        private readonly INewsSubcategoryRepository _newsSubcategoryRepository;
+        private readonly IReaderUserRepository _readerUserRepository;
+        private readonly IProfessionalInformationRepository _professionalInformationRepository;
+        private readonly IProfessionalSkillRepository _professionalSkillRepository;
+        private readonly IFormationRepository _formationRepository;
+        private readonly IMapper _mapper;
+        private readonly FirestoreDb _firestoreDb;
+        public FirestoreToSqlServerDataStreamingService(IUserWithNewsRepository userWithNewsRepository, INewsRepository newsRepository, INewsCategoryRepository newsCategoryRepository, INewsSubcategoryRepository newsSubcategoryRepository, IReaderUserRepository readerUserRepository, IProfessionalInformationRepository professionalInformationRepository, IProfessionalSkillRepository professionalSkillRepository, IFormationRepository formationRepository, IMapper mapper)
+        {
+            _userWithNewsRepository = userWithNewsRepository;
+            _newsRepository = newsRepository;
+            _newsCategoryRepository = newsCategoryRepository;
+            _newsSubcategoryRepository = newsSubcategoryRepository;
+            _readerUserRepository = readerUserRepository;
+            _professionalInformationRepository = professionalInformationRepository;
+            _professionalSkillRepository = professionalSkillRepository;
+            _formationRepository = formationRepository;
+            _mapper = mapper;
+            GoogleCredential credential = GoogleCredential.FromJson(Environment.GetEnvironmentVariable("GWINEWS_FIRESTORE_API_KEY"));
+            FirestoreClientBuilder builder = new FirestoreClientBuilder
+            {
+                Credential = credential
+            };
+            _firestoreDb = FirestoreDb.Create("gwinews-teste", builder.Build());
+        }
+
+        public async Task<ResponseModelDTO<bool>> DataStreamingCaller()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                response = await UserWithNewsDataStreaming();
+                response = await NewsCategoryDataStreaming();
+                response = await NewsSubcategoryDataStreaming();
+                response = await ReaderUserDataStreaming();
+                response = await ProfessionalInformationDataStreaming();
+                response = await ProfessionalSkillNewsDataStreaming();
+                response = await FormationNewsDataStreaming();
+
+                response.Message = "Streaming de Dados Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> UserWithNewsDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var usersWithNewsSql = await _userWithNewsRepository.GetUsersWithNews();
+
+                var collection = _firestoreDb.Collection("UsersWithNews");
+                var snapshot = await collection.GetSnapshotAsync();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    UserRole userRole = (UserRole)snapshot[i].GetValue<int>("Role");
+                    string completeName = snapshot[i].GetValue<string>("CompleteName");
+                    string email = snapshot[i].GetValue<string>("Email");
+                    string password = snapshot[i].GetValue<string>("Password");
+                    bool status = snapshot[i].GetValue<bool>("Status");
+                    UserWithNews userWithNews = new UserWithNews
+                    {
+                        Id = id,
+                        Role = userRole,
+                        CompleteName = completeName,
+                        Email = email,
+                        Password = password,
+                        Status = status
+                    };
+                    if (usersWithNewsSql.Any(u => u.Id == userWithNews.Id))
+                    {
+                        await _userWithNewsRepository.UpdateUserWithNews(userWithNews);
+                    }
+                    else
+                    {
+                        await _userWithNewsRepository.CreateUserWithNews(userWithNews);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Usuários com Notícias Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> NewsCategoryDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var newsCategoriesSql = await _newsCategoryRepository.GetNewsCategories();
+
+                var collection = _firestoreDb.Collection("NewsCategories");
+                var snapshot = await collection.GetSnapshotAsync();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    string name = snapshot[i].GetValue<string>("Name");
+                    bool status = snapshot[i].GetValue<bool>("Status");
+                    NewsCategory newsCategory = new NewsCategory
+                    {
+                        Id = id,
+                        Name = name,
+                        Status = status
+                    };
+                    if (newsCategoriesSql.Any(nc => nc.Id == newsCategory.Id))
+                    {
+                        await _newsCategoryRepository.UpdateNewsCategory(newsCategory);
+                    }
+                    else
+                    {
+                        await _newsCategoryRepository.CreateNewsCategory(newsCategory);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Categorias de Notícias Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> NewsSubcategoryDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var newsSubcategoriesSql = await _newsSubcategoryRepository.GetNewsSubcategories();
+
+                var collection = _firestoreDb.Collection("NewsSubcategories");
+                var snapshot = await collection.GetSnapshotAsync();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    string name = snapshot[i].GetValue<string>("Name");
+                    bool status = snapshot[i].GetValue<bool>("Status");
+                    Guid categoryId = Guid.Parse(snapshot[i].GetValue<string>("CategoryId"));
+                    NewsSubcategory newsSubcategory = new NewsSubcategory
+                    {
+                        Id = id,
+                        Name = name,
+                        Status = status,
+                        CategoryId = categoryId
+                    };
+                    if (newsSubcategoriesSql.Any(nc => nc.Id == newsSubcategory.Id))
+                    {
+                        await _newsSubcategoryRepository.UpdateNewsSubcategory(newsSubcategory);
+                    }
+                    else
+                    {
+                        await _newsSubcategoryRepository.CreateNewsSubcategory(newsSubcategory);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Subcategorias de Notícias Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> NewsDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var newsSql = await _newsRepository.GetNews();
+
+                var collection = _firestoreDb.Collection("News");
+                var snapshot = await collection.GetSnapshotAsync();
+                var subcategoriesSql = await _newsSubcategoryRepository.GetNewsSubcategories();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    NewsStatusDTO status = (NewsStatusDTO)snapshot[i].GetValue<int>("Status");
+                    string newsUrl = snapshot[i].GetValue<string>("NewsUrl");
+                    string title = snapshot[i].GetValue<string>("Title");
+                    string subtitle = snapshot[i].GetValue<string>("Subtitle");
+                    string newsBody = snapshot[i].GetValue<string>("NewsBody");
+                    string imgUrl = snapshot[i].GetValue<string>("ImageUrl");
+                    DateTime publishDate = snapshot[i].GetValue<DateTime>("PublishDate");
+                    Guid authorId = Guid.Parse(snapshot[i].GetValue<string>("AuthorId"));
+                    Guid editorId = Guid.Parse(snapshot[i].GetValue<string>("EditorId"));
+                    Guid categoryId = Guid.Parse(snapshot[i].GetValue<string>("CategoryId"));
+                    string[] subcategoriesArray = snapshot[i].GetValue<string[]>("Subcategories");
+                    UpdateNewsDTO news = new UpdateNewsDTO
+                    {
+                        Id = id,
+                        Status = status,
+                        NewsUrl = newsUrl,
+                        Title = title,
+                        Subtitle = subtitle,
+                        NewsBody = newsBody,
+                        ImageUrl = imgUrl,
+                        PublishDate = publishDate,
+                        AuthorId = authorId,
+                        EditorId = editorId,
+                        CategoryId = categoryId,
+                        Subcategories = new List<NewsSubcategory>()
+                    };
+                    foreach (var subcategory in subcategoriesArray)
+                    {
+                        var newsSubcategory = subcategoriesSql.FirstOrDefault(sc => sc.Id == Guid.Parse(subcategory));
+                        news.Subcategories.Add(newsSubcategory);
+                    }
+                    if (newsSql.Any(u => u.Id == news.Id))
+                    {
+                        var newsMapped = _mapper.Map<News>(news);
+                        await _newsRepository.UpdateNews(newsMapped);
+                    }
+                    else
+                    {
+                        var newsMapped = _mapper.Map<News>(news);
+                        await _newsRepository.CreateNews(newsMapped);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Notícias Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> ReaderUserDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var readerUsersSql = await _readerUserRepository.GetReaderUsers();
+
+                var collection = _firestoreDb.Collection("ReaderUsers");
+                var snapshot = await collection.GetSnapshotAsync();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    UserRole userRole = (UserRole)snapshot[i].GetValue<int>("Role");
+                    string completeName = snapshot[i].GetValue<string>("CompleteName");
+                    string email = snapshot[i].GetValue<string>("Email");
+                    string password = snapshot[i].GetValue<string>("Password");
+                    bool status = snapshot[i].GetValue<bool>("Status");
+                    ReaderUser readerUser = new ReaderUser
+                    {
+                        Id = id,
+                        Role = userRole,
+                        CompleteName = completeName,
+                        Email = email,
+                        Password = password,
+                        Status = status
+                    };
+                    if (readerUsersSql.Any(u => u.Id == readerUser.Id))
+                    {
+                        await _readerUserRepository.UpdateReaderUser(readerUser);
+                    }
+                    else
+                    {
+                        await _readerUserRepository.CreateReaderUser(readerUser);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Usuários Leitores Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> ProfessionalInformationDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var professionalInformationsSql = await _professionalInformationRepository.GetProfessionalInformations();
+
+                var collection = _firestoreDb.Collection("ProfessionalInformations");
+                var snapshot = await collection.GetSnapshotAsync();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    string completeName = snapshot[i].GetValue<string>("CompleteName");
+                    string email = snapshot[i].GetValue<string>("Email");
+                    string completeAddress = snapshot[i].GetValue<string>("CompleteAddress");
+                    string objective = snapshot[i].GetValue<string>("Objective");
+                    string imgUrl = snapshot[i].GetValue<string>("ImageUrl");
+                    string workPlatform = snapshot[i].GetValue<string>("WorkPlatform");
+                    bool status = snapshot[i].GetValue<bool>("Status");
+                    Guid userId = Guid.Parse(snapshot[i].GetValue<string>("UserId"));
+                    ProfessionalInformation professionalInformation = new ProfessionalInformation
+                    {
+                        Id = id,
+                        CompleteName = completeName,
+                        Email = email,
+                        CompleteAddress = completeAddress,
+                        Objective = objective,
+                        ImgUrl = imgUrl,
+                        WorkPlatformUrl = workPlatform,
+                        Status = status,
+                        UserId = userId
+                    };
+                    if (professionalInformationsSql.Any(pi => pi.Id == professionalInformation.Id))
+                    {
+                        await _professionalInformationRepository.UpdateProfessionalInformation(professionalInformation);
+                    }
+                    else
+                    {
+                        await _professionalInformationRepository.CreateProfessionalInformation(professionalInformation);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Informações Profissionais Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> ProfessionalSkillNewsDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var professionalSkillsSql = await _professionalSkillRepository.GetProfessionalSkills();
+
+                var collection = _firestoreDb.Collection("ProfessionalSkills");
+                var snapshot = await collection.GetSnapshotAsync();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    string skill1 = snapshot[i].GetValue<string>("Skill1");
+                    string skill2 = snapshot[i].GetValue<string>("Skill2");
+                    string skill3 = snapshot[i].GetValue<string>("Skill3");
+                    string skill4 = snapshot[i].GetValue<string>("Skill4");
+                    bool status = snapshot[i].GetValue<bool>("Status");
+                    Guid userId = Guid.Parse(snapshot[i].GetValue<string>("UserId"));
+                    ProfessionalSkill professionalSkill = new ProfessionalSkill
+                    {
+                        Id = id,
+                        Skill1 = skill1,
+                        Skill2 = skill2,
+                        Skill3 = skill3,
+                        Skill4 = skill4,
+                        Status = status,
+                        UserId = userId
+                    };
+                    if (professionalSkillsSql.Any(pi => pi.Id == professionalSkill.Id))
+                    {
+                        await _professionalSkillRepository.UpdateProfessionalSkill(professionalSkill);
+                    }
+                    else
+                    {
+                        await _professionalSkillRepository.CreateProfessionalSkill(professionalSkill);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Habilidades Profissionais Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+
+        public async Task<ResponseModelDTO<bool>> FormationNewsDataStreaming()
+        {
+            ResponseModelDTO<bool> response = new ResponseModelDTO<bool>();
+            try
+            {
+                var formationsSql = await _formationRepository.GetFormations();
+
+                var collection = _firestoreDb.Collection("Formations");
+                var snapshot = await collection.GetSnapshotAsync();
+                for (int i = 0; i < snapshot.Count; i++)
+                {
+                    Guid id = Guid.Parse(snapshot[i].Id);
+                    string name = snapshot[i].GetValue<string>("Name");
+                    string institution = snapshot[i].GetValue<string>("Institution");
+                    DateTime startDate = snapshot[i].GetValue<DateTime>("StartDate");
+                    DateTime endDate = snapshot[i].GetValue<DateTime>("EndDate");
+                    string activity1 = snapshot[i].GetValue<string>("Activity1");
+                    string activity2 = snapshot[i].GetValue<string>("Activity2");
+                    string activity3 = snapshot[i].GetValue<string>("Activity3");
+                    bool status = snapshot[i].GetValue<bool>("Status");
+                    Guid userId = Guid.Parse(snapshot[i].GetValue<string>("UserId"));
+                    Formation formation = new Formation
+                    {
+                        Id = id,
+                        Name = name,
+                        Institution = institution,
+                        StartDate = startDate,
+                        EndDate = endDate,
+                        Activity1 = activity1,
+                        Activity2 = activity2,
+                        Activity3 = activity3,
+                        Status = status,
+                        UserId = userId
+                    };
+                    if (formationsSql.Any(pi => pi.Id == formation.Id))
+                    {
+                        await _formationRepository.UpdateFormation(formation);
+                    }
+                    else
+                    {
+                        await _formationRepository.CreateFormation(formation);
+                    }
+                }
+
+                response.Data = true;
+                response.Message = "Streaming de Dados de Formações Realizado com Sucesso.";
+                return response;
+            }
+            catch (Exception ex)
+            {
+                response.Data = false;
+                response.Message = ex.Message;
+                response.Status = false;
+                return response;
+            }
+        }
+    }
+}

--- a/GwiNews/GwiNews.Domain/Entities/Formation.cs
+++ b/GwiNews/GwiNews.Domain/Entities/Formation.cs
@@ -29,7 +29,6 @@ namespace GwiNews.Domain.Entities
         public bool? Status { get; set; }
         [Required]
         public Guid? UserId { get; set; }
-        [Required]
         public ReaderUser? User { get; set; }
     }
 }

--- a/GwiNews/GwiNews.Domain/Entities/News.cs
+++ b/GwiNews/GwiNews.Domain/Entities/News.cs
@@ -27,15 +27,12 @@ namespace GwiNews.Domain.Entities
         public DateTime? PublishDate { get; set; }
         [Required]
         public Guid? AuthorId { get; set; }
-        [Required]
         public UserWithNews? Author { get; set; }
         [Required]
         public Guid? EditorId { get; set; }
-        [Required]
         public UserWithNews? Editor { get; set; }
         [Required]
         public Guid? CategoryId { get; set; }
-        [Required]
         public NewsCategory? Category { get; set; }
         public ICollection<NewsSubcategory>? Subcategories { get; set; }
         public ICollection<ReaderUser>? FavoritedBy { get; set; }

--- a/GwiNews/GwiNews.Domain/Entities/NewsSubcategory.cs
+++ b/GwiNews/GwiNews.Domain/Entities/NewsSubcategory.cs
@@ -13,7 +13,6 @@ namespace GwiNews.Domain.Entities
         public bool? Status { get; set; }
         [Required]
         public Guid? CategoryId { get; set; }
-        [Required]
         public NewsCategory? Category { get; set; }
         public ICollection<News>? News { get; set; }
     }

--- a/GwiNews/GwiNews.Domain/Entities/ProfessionalInformation.cs
+++ b/GwiNews/GwiNews.Domain/Entities/ProfessionalInformation.cs
@@ -28,7 +28,6 @@ namespace GwiNews.Domain.Entities
         public string? WorkPlatformUrl { get; set; }
         [Required]
         public Guid? UserId { get; set; }
-        [Required]
         public ReaderUser? User { get; set; }
     }
 }

--- a/GwiNews/GwiNews.Domain/Entities/ProfessionalSkill.cs
+++ b/GwiNews/GwiNews.Domain/Entities/ProfessionalSkill.cs
@@ -22,7 +22,6 @@ namespace GwiNews.Domain.Entities
         public bool? Status { get; set; }
         [Required]
         public Guid? UserId { get; set; }
-        [Required]
         public ReaderUser? User { get; set; }
     }
 }

--- a/GwiNews/GwiNews.Infra.Data/Repository/FormationRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/FormationRepository.cs
@@ -96,6 +96,13 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
+                var trackedEntity = _context.ChangeTracker.Entries<Formation>()
+                    .FirstOrDefault(e => e.Entity.Id == formation.Id);
+                if (trackedEntity != null)
+                {
+                    _context.Entry(trackedEntity.Entity).State = EntityState.Detached;
+                }
+    
                 _context.Update(formation);
                 await _context.SaveChangesAsync();
                 return formation;

--- a/GwiNews/GwiNews.Infra.Data/Repository/NewsCategoryRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/NewsCategoryRepository.cs
@@ -73,6 +73,13 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
+                var trackedEntity = _context.ChangeTracker.Entries<NewsCategory>()
+                    .FirstOrDefault(e => e.Entity.Id == newsCategory.Id);
+                if (trackedEntity != null)
+                {
+                    _context.Entry(trackedEntity.Entity).State = EntityState.Detached;
+                }
+    
                 _context.Update(newsCategory);
                 await _context.SaveChangesAsync();
                 return newsCategory;

--- a/GwiNews/GwiNews.Infra.Data/Repository/NewsSubcategoryRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/NewsSubcategoryRepository.cs
@@ -85,6 +85,13 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
+                var trackedEntity = _context.ChangeTracker.Entries<NewsSubcategory>()
+                    .FirstOrDefault(e => e.Entity.Id == newsSubcategory.Id);
+                if (trackedEntity != null)
+                {
+                    _context.Entry(trackedEntity.Entity).State = EntityState.Detached;
+                }
+
                 _context.Update(newsSubcategory);
                 await _context.SaveChangesAsync();
                 return newsSubcategory;

--- a/GwiNews/GwiNews.Infra.Data/Repository/ProfessionalInformationRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/ProfessionalInformationRepository.cs
@@ -96,6 +96,13 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
+                var trackedEntity = _context.ChangeTracker.Entries<ProfessionalInformation>()
+                    .FirstOrDefault(e => e.Entity.Id == professionalInformation.Id);
+                if (trackedEntity != null)
+                {
+                    _context.Entry(trackedEntity.Entity).State = EntityState.Detached;
+                }
+
                 _context.Update(professionalInformation);
                 await _context.SaveChangesAsync();
                 return professionalInformation;

--- a/GwiNews/GwiNews.Infra.Data/Repository/ProfessionalSkillRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/ProfessionalSkillRepository.cs
@@ -96,6 +96,13 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
+                var trackedEntity = _context.ChangeTracker.Entries<ProfessionalSkill>()
+                    .FirstOrDefault(e => e.Entity.Id == professionalSkill.Id);
+                if (trackedEntity != null)
+                {
+                    _context.Entry(trackedEntity.Entity).State = EntityState.Detached;
+                }
+
                 _context.Update(professionalSkill);
                 await _context.SaveChangesAsync();
                 return professionalSkill;

--- a/GwiNews/GwiNews.Infra.Data/Repository/ReaderUserRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/ReaderUserRepository.cs
@@ -75,6 +75,13 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
+                var trackedEntity = _context.ChangeTracker.Entries<ReaderUser>()
+                    .FirstOrDefault(e => e.Entity.Id == readerUser.Id);
+                if (trackedEntity != null)
+                {
+                    _context.Entry(trackedEntity.Entity).State = EntityState.Detached;
+                }
+
                 _context.Update(readerUser);
                 await _context.SaveChangesAsync();
                 return readerUser;

--- a/GwiNews/GwiNews.Infra.Data/Repository/UserWithNewsRepository.cs
+++ b/GwiNews/GwiNews.Infra.Data/Repository/UserWithNewsRepository.cs
@@ -73,6 +73,13 @@ namespace GwiNews.Infra.Data.Repository
         {
             try
             {
+                var trackedEntity = _context.ChangeTracker.Entries<UserWithNews>()
+                    .FirstOrDefault(e => e.Entity.Id == userWithNews.Id);
+                if (trackedEntity != null)
+                {
+                    _context.Entry(trackedEntity.Entity).State = EntityState.Detached;
+                }
+
                 _context.Update(userWithNews);
                 await _context.SaveChangesAsync();
                 return userWithNews;

--- a/GwiNews/GwiNews.Infra.IoC/DependencyInjectionAPI.cs
+++ b/GwiNews/GwiNews.Infra.IoC/DependencyInjectionAPI.cs
@@ -34,8 +34,24 @@ namespace GwiNews.Infra.IoC
             services.AddScoped<IProfessionalInformationService, ProfessionalInformationService>();
             services.AddScoped<IProfessionalSkillService, ProfessionalSkillService>();
             services.AddScoped<IFormationService, FormationService>();
+            services.AddScoped<IFirestoreToSqlServerDataStreamingService, FirestoreToSqlServerDataStreamingService>();
 
             services.AddAutoMapper(typeof(DtoToDomainMappingProfile));
+
+            try
+            {
+                string firestoreKeyPath = Path.Combine(AppContext.BaseDirectory, "gwinews-firestore-api-key.json");
+                string firestoreKeyContent = File.ReadAllText(firestoreKeyPath);
+                Environment.SetEnvironmentVariable("GWINEWS_FIRESTORE_API_KEY", firestoreKeyContent);
+            }
+            catch (Exception ex)
+            {
+                string firestoreKeyContent = Environment.GetEnvironmentVariable("GWINEWS_FIRESTORE_API_KEY");
+                if (string.IsNullOrEmpty(firestoreKeyContent))
+                {
+                    throw new InvalidOperationException("A variável de ambiente GWINEWS_FIRESTORE_API_KEY não está definida.");
+                }
+            }
 
             return services;
         }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,8 @@ steps:
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="$(build.artifactStagingDirectory)\WebApp.zip" /p:DeployIisAppPath="Default Web Site"'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+    env:
+      GWINEWS_FIRESTORE_API_KEY: $(GWINEWS_FIRESTORE_API_KEY)
 
 - task: VSTest@2
   inputs:


### PR DESCRIPTION
Autor: @GabrielFePL.
Task: Epic 524/Feature 544/Task 629.
Data: 27/01/2025.

Log de Alterações:

- Adição: Variável de Ambiente adicionada ao .gitignore;
- Adição: Classe Controller FirestoreToSqlServerDataStreamingController adicionada em Controllers;
- Adição: Pacotes NuGet Google.Cloud.Firestore e Google.Apis.Auth adicionados em GwiNews.Application;
- Adição: Interface IFirestoreToSqlServerDataStreamingService em Interfaces;
- Adição: Métodos FormationNewsDataStreaming, ProfessionalSkillNewsDataStreaming, ProfessionalInformationDataStreaming, ReaderUserDataStreaming, NewsDataStreaming, NewsSubcategoryDataStreaming, NewsCategoryDataStreaming, UserWithNewsDataStreaming e DataStreamingCaller em IFirestoreToSqlServerDataStreamingService;
- Adição: Associação entre Interface e Classe FirestoreToSqlServerDataStreamingService em DependencyInjectionAPI;
- Adição: Variável de Ambiente GWINEWS_FIRESTORE_API_KEY em DependencyInjectionAPI;
- Adição: Variável de Ambiente GWINEWS_FIRESTORE_API_KEY em azure-pipelines.yaml;
- Alteração: Data Annotation [Required] removidos das propriedades de navegação das classes em Domain;
- Alteração: Métodos Update alterados para tratar exceção de rastreamento duplicado pelo ORM nas classes de Repository;
- Alteração: Método GetById atualizado para retornar relacionamentos com NewsSubcategory em NewsRepository;
- Alteração: Método Update atualizado para persistir dados de relacionamentos com NewsSubcategory em NewsRepository;
- Alteração: Enums de DTOs e suas referências renomeados para UserRoleDTO e NewsStatusDTO;